### PR TITLE
mrc-4198 restore

### DIFF
--- a/src/privateer/backup.py
+++ b/src/privateer/backup.py
@@ -53,8 +53,6 @@ def restore(host: PrivateerHost, targets: List[PrivateerTarget]):
                     remote_path = os.path.join(host.path, f"{t.name}.tar")
                     try:
                         c.run(f"test -f {remote_path}", in_stream=False)
-                        if not os.path.exists(local_backup_path):
-                            os.mkdir(local_backup_path)
                         c.get(remote_path, f"{local_backup_path}/")
                         untar_volume(t, local_backup_path)
                         success.append(t.name)

--- a/src/privateer/backup.py
+++ b/src/privateer/backup.py
@@ -21,8 +21,7 @@ def backup(host: PrivateerHost, targets: List[PrivateerTarget]):
             res = shutil.copy(path, host.path)
             print(f"Copied {path} to {res}")
     else:
-        with Connection(host=host.hostname, user=host.user,
-                        port=host.port) as c:
+        with Connection(host=host.hostname, user=host.user, port=host.port) as c:
             try:
                 c.run(f"test -d {host.path}", in_stream=False)
             except UnexpectedExit:
@@ -46,18 +45,15 @@ def restore(host: PrivateerHost, targets: List[PrivateerTarget]):
                 untar_volume(t, host.path)
                 print(f"Restored {path} to {t.name}")
     else:
-        with Connection(host=host.hostname, user=host.user,
-                        port=host.port) as c:
+        with Connection(host=host.hostname, user=host.user, port=host.port) as c:
             with tempfile.TemporaryDirectory() as local_backup_path:
                 for t in targets:
                     remote_path = os.path.join(host.path, f"{t.name}.tar")
                     try:
-                        print(f"Restoring {remote_path} to {t.name}")
                         c.run(f"test -f {remote_path}", in_stream=False)
                         if not os.path.exists(local_backup_path):
                             os.mkdir(local_backup_path)
-                        res = c.get(remote_path, f"{local_backup_path}/")
-                        print(f"Downloaded {res.local} from {res.remote}")
+                        c.get(remote_path, f"{local_backup_path}/")
                         untar_volume(t, local_backup_path)
                         print(f"Restored {remote_path} to {t.name}")
                     except UnexpectedExit:
@@ -78,8 +74,7 @@ def tar_volume(target: PrivateerTarget):
             "ubuntu",
             remove=True,
             mounts=[volume_mount, backup_mount],
-            command=["tar", "cvf", f"/backup/{target.name}.tar", "-C", "/data",
-                     "."],
+            command=["tar", "cvf", f"/backup/{target.name}.tar", "-C", "/data", "."],
         )
     return f"{local_backup_path}/{target.name}.tar"
 

--- a/src/privateer/cli.py
+++ b/src/privateer/cli.py
@@ -11,7 +11,7 @@ Options:
 import docopt
 
 import privateer.__about__ as about
-from privateer.backup import backup
+from privateer.backup import backup, restore
 from privateer.config import PrivateerConfig
 
 
@@ -21,17 +21,24 @@ def main(argv=None):
         return about.__version__
     cfg = PrivateerConfig(opts["<path>"])
     targets = get_targets(opts["--include"], opts["--exclude"], cfg.targets)
-    names = ", ".join([f"'{t.name}'" for t in targets])
     if len(targets) == 0:
         return "No targets selected. Doing nothing."
     if opts["backup"]:
         host = cfg.get_host(opts["--to"])
-        msg = f"Backed up targets {names} to host '{host.name}'"
+        names = ", ".join([f"'{t.name}'" for t in targets])
+        target_str = "targets" if len(targets) > 1 else "target"
+        msg = f"Backed up {target_str} {names} to host '{host.name}'"
         backup(host, targets)
         return msg
     elif opts["restore"]:
         host = cfg.get_host(opts["--from"])
-        msg = f"Restored targets {names} from host '{host.name}'"
+        success = restore(host, targets)
+        if len(success) > 0:
+            names = ", ".join([f"'{s}'" for s in success])
+            target_str = "targets" if len(success) > 1 else "target"
+            msg = f"Restored {target_str} {names} from host '{host.name}'"
+        else:
+            msg = "No valid backups found. Doing nothing."
         return msg
 
 

--- a/src/privateer/config.py
+++ b/src/privateer/config.py
@@ -43,4 +43,7 @@ class PrivateerConfig:
         if len(match) > 1:
             msg = f"Invalid arguments: two hosts with the name '{name}' found."
             raise Exception(msg)
+        if len(match) == 0:
+            msg = f"Invalid arguments: no host with the name '{name}' found."
+            raise Exception(msg)
         return match[0]

--- a/src/privateer/config.py
+++ b/src/privateer/config.py
@@ -1,4 +1,5 @@
 import json
+import os.path
 
 
 class PrivateerHost:
@@ -10,6 +11,9 @@ class PrivateerHost:
         self.name = dat["name"]
         self.host_type = host_type
         self.path = dat["path"]
+        if host_type == "local" and not os.path.isabs(self.path):
+            self.path = os.path.abspath(self.path)
+            print(f"Relative path provided; resolving to {self.path}")
         if host_type == "remote":
             self.hostname = dat["hostname"]
             if "user" in dat:

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -6,7 +6,7 @@ from os import listdir
 import docker
 import pytest
 
-from src.privateer.backup import backup, tar_volume, untar_volume, restore
+from src.privateer.backup import backup, restore, tar_volume, untar_volume
 from src.privateer.config import PrivateerConfig, PrivateerTarget
 from src.privateer.docker_helpers import DockerClient
 
@@ -15,10 +15,8 @@ def test_tar_volume():
     test_vol = docker.types.Mount("/data", "privateer_test")
     try:
         with DockerClient() as cl:
-            cl.containers.run("ubuntu", mounts=[test_vol], remove=True,
-                              command=["touch", "/data/test.txt"])
-            target = PrivateerTarget(
-                {"name": "privateer_test", "type": "volume"})
+            cl.containers.run("ubuntu", mounts=[test_vol], remove=True, command=["touch", "/data/test.txt"])
+            target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
             res = tar_volume(target)
             assert res.endswith("privateer_test.tar")
             res = tarfile.open(res)
@@ -37,10 +35,8 @@ def test_untar_volume():
     test_vol = docker.types.Mount("/data", "privateer_test")
     try:
         with DockerClient() as cl:
-            cl.containers.run("ubuntu", mounts=[test_vol], remove=True,
-                              command=["touch", "/data/test.txt"])
-            target = PrivateerTarget(
-                {"name": "privateer_test", "type": "volume"})
+            cl.containers.run("ubuntu", mounts=[test_vol], remove=True, command=["touch", "/data/test.txt"])
+            target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
             res = tar_volume(target)
             # remove the volume to test restore path
             v = cl.volumes.get("privateer_test")
@@ -50,8 +46,7 @@ def test_untar_volume():
             assert res is True
             # check test.txt has been restored to volume
             container = cl.containers.run(
-                "ubuntu", mounts=[test_vol], detach=True,
-                command=["test", "-f", "/data/test.txt"]
+                "ubuntu", mounts=[test_vol], detach=True, command=["test", "-f", "/data/test.txt"]
             )
             result = container.wait()
             container.remove()
@@ -85,8 +80,7 @@ def test_restore_local():
     test_vol = docker.types.Mount("/data", "privateer_test")
     target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
     with DockerClient() as cl:
-        cl.containers.run("ubuntu", mounts=[test_vol], remove=True,
-                          command=["touch", "/data/test.txt"])
+        cl.containers.run("ubuntu", mounts=[test_vol], remove=True, command=["touch", "/data/test.txt"])
         backup(host, [target])
         # remove the volume to test restore path
         v = cl.volumes.get("privateer_test")
@@ -96,8 +90,7 @@ def test_restore_local():
         assert res is True
         # check test.txt has been restored to volume
         container = cl.containers.run(
-            "ubuntu", mounts=[test_vol], detach=True,
-            command=["test", "-f", "/data/test.txt"]
+            "ubuntu", mounts=[test_vol], detach=True, command=["test", "-f", "/data/test.txt"]
         )
         result = container.wait()
         container.remove()
@@ -110,8 +103,7 @@ def test_restore_remote():
     test_vol = docker.types.Mount("/data", "privateer_test")
     target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
     with DockerClient() as cl:
-        cl.containers.run("ubuntu", mounts=[test_vol], remove=True,
-                          command=["touch", "/data/test.txt"])
+        cl.containers.run("ubuntu", mounts=[test_vol], remove=True, command=["touch", "/data/test.txt"])
         backup(host, [target])
         # remove the volume to test restore path
         v = cl.volumes.get("privateer_test")
@@ -121,13 +113,11 @@ def test_restore_remote():
         assert res is True
         # check test.txt has been restored to volume
         container = cl.containers.run(
-            "ubuntu", mounts=[test_vol], detach=True,
-            command=["test", "-f", "/data/test.txt"]
+            "ubuntu", mounts=[test_vol], detach=True, command=["test", "-f", "/data/test.txt"]
         )
         result = container.wait()
         container.remove()
         assert result["StatusCode"] == 0
-
 
 
 def test_remote_host_dir_validation():
@@ -138,8 +128,7 @@ def test_remote_host_dir_validation():
     uat.path = "badpath"
     with pytest.raises(Exception) as err:
         backup(uat, cfg.targets)
-    assert str(
-        err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."
+    assert str(err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."
 
 
 def test_local_host_dir_validation():
@@ -148,5 +137,4 @@ def test_local_host_dir_validation():
     test.path = "badpath"
     with pytest.raises(Exception) as err:
         backup(test, cfg.targets)
-    assert str(
-        err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."
+    assert str(err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -81,7 +81,7 @@ def test_restore_local():
         v.remove()
         # restore
         res = restore(host, [target])
-        assert res is True
+        assert res == ["privateer_test"]
         # check test.txt has been restored to volume
         container = cl.containers.run(
             "ubuntu", mounts=[test_vol], detach=True, command=["test", "-f", "/data/test.txt"]
@@ -108,7 +108,7 @@ def test_restore_remote():
         v.remove()
         # restore
         res = restore(host, [target])
-        assert res is True
+        assert res == ["privateer_test"]
         # check test.txt has been restored to volume
         container = cl.containers.run(
             "ubuntu", mounts=[test_vol], detach=True, command=["test", "-f", "/data/test.txt"]

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -6,7 +6,7 @@ from os import listdir
 import docker
 import pytest
 
-from src.privateer.backup import backup, tar_volume, untar_volume
+from src.privateer.backup import backup, tar_volume, untar_volume, restore
 from src.privateer.config import PrivateerConfig, PrivateerTarget
 from src.privateer.docker_helpers import DockerClient
 
@@ -15,8 +15,10 @@ def test_tar_volume():
     test_vol = docker.types.Mount("/data", "privateer_test")
     try:
         with DockerClient() as cl:
-            cl.containers.run("ubuntu", mounts=[test_vol], remove=True, command=["touch", "/data/test.txt"])
-            target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
+            cl.containers.run("ubuntu", mounts=[test_vol], remove=True,
+                              command=["touch", "/data/test.txt"])
+            target = PrivateerTarget(
+                {"name": "privateer_test", "type": "volume"})
             res = tar_volume(target)
             assert res.endswith("privateer_test.tar")
             res = tarfile.open(res)
@@ -35,8 +37,10 @@ def test_untar_volume():
     test_vol = docker.types.Mount("/data", "privateer_test")
     try:
         with DockerClient() as cl:
-            cl.containers.run("ubuntu", mounts=[test_vol], remove=True, command=["touch", "/data/test.txt"])
-            target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
+            cl.containers.run("ubuntu", mounts=[test_vol], remove=True,
+                              command=["touch", "/data/test.txt"])
+            target = PrivateerTarget(
+                {"name": "privateer_test", "type": "volume"})
             res = tar_volume(target)
             # remove the volume to test restore path
             v = cl.volumes.get("privateer_test")
@@ -46,7 +50,8 @@ def test_untar_volume():
             assert res is True
             # check test.txt has been restored to volume
             container = cl.containers.run(
-                "ubuntu", mounts=[test_vol], detach=True, command=["test", "-f", "/data/test.txt"]
+                "ubuntu", mounts=[test_vol], detach=True,
+                command=["test", "-f", "/data/test.txt"]
             )
             result = container.wait()
             container.remove()
@@ -71,6 +76,60 @@ def test_backup_local():
     assert os.path.isfile(os.path.join(test.path, "orderly_volume.tar"))
 
 
+def test_restore_local():
+    if os.getenv("GITHUB_ACTIONS"):
+        pytest.skip("No access to network")
+    cfg = PrivateerConfig("config")
+    host = cfg.get_host("test")
+    host.path = tempfile.mkdtemp()
+    test_vol = docker.types.Mount("/data", "privateer_test")
+    target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
+    with DockerClient() as cl:
+        cl.containers.run("ubuntu", mounts=[test_vol], remove=True,
+                          command=["touch", "/data/test.txt"])
+        backup(host, [target])
+        # remove the volume to test restore path
+        v = cl.volumes.get("privateer_test")
+        v.remove()
+        # restore
+        res = restore(host, [target])
+        assert res is True
+        # check test.txt has been restored to volume
+        container = cl.containers.run(
+            "ubuntu", mounts=[test_vol], detach=True,
+            command=["test", "-f", "/data/test.txt"]
+        )
+        result = container.wait()
+        container.remove()
+        assert result["StatusCode"] == 0
+
+
+def test_restore_remote():
+    cfg = PrivateerConfig("config")
+    host = cfg.get_host("uat")
+    test_vol = docker.types.Mount("/data", "privateer_test")
+    target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
+    with DockerClient() as cl:
+        cl.containers.run("ubuntu", mounts=[test_vol], remove=True,
+                          command=["touch", "/data/test.txt"])
+        backup(host, [target])
+        # remove the volume to test restore path
+        v = cl.volumes.get("privateer_test")
+        v.remove()
+        # restore
+        res = restore(host, [target])
+        assert res is True
+        # check test.txt has been restored to volume
+        container = cl.containers.run(
+            "ubuntu", mounts=[test_vol], detach=True,
+            command=["test", "-f", "/data/test.txt"]
+        )
+        result = container.wait()
+        container.remove()
+        assert result["StatusCode"] == 0
+
+
+
 def test_remote_host_dir_validation():
     if os.getenv("GITHUB_ACTIONS"):
         pytest.skip("No access to network")
@@ -79,7 +138,8 @@ def test_remote_host_dir_validation():
     uat.path = "badpath"
     with pytest.raises(Exception) as err:
         backup(uat, cfg.targets)
-    assert str(err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."
+    assert str(
+        err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."
 
 
 def test_local_host_dir_validation():
@@ -88,4 +148,5 @@ def test_local_host_dir_validation():
     test.path = "badpath"
     with pytest.raises(Exception) as err:
         backup(test, cfg.targets)
-    assert str(err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."
+    assert str(
+        err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -68,8 +68,6 @@ def test_backup_local():
 
 
 def test_restore_local():
-    if os.getenv("GITHUB_ACTIONS"):
-        pytest.skip("No access to network")
     cfg = PrivateerConfig("config")
     host = cfg.get_host("test")
     host.path = tempfile.mkdtemp()
@@ -96,6 +94,8 @@ def test_restore_local():
 
 
 def test_restore_remote():
+    if os.getenv("GITHUB_ACTIONS"):
+        pytest.skip("No access to network")
     cfg = PrivateerConfig("config")
     host = cfg.get_host("uat")
     test_vol = docker.types.Mount("/data", "privateer_test")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,3 +41,10 @@ def test_unique_hosts():
     with pytest.raises(Exception) as err:
         cfg.get_host("annex")
     assert str(err.value) == "Invalid arguments: two hosts with the name 'annex' found."
+
+
+def test_existent_hosts():
+    cfg = PrivateerConfig("config/invalid")
+    with pytest.raises(Exception) as err:
+        cfg.get_host("badname")
+    assert str(err.value) == "Invalid arguments: no host with the name 'badname' found."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from src.privateer.config import PrivateerConfig, PrivateerHost, PrivateerTarget
@@ -20,7 +22,8 @@ def test_config():
     assert cfg.hosts[1].host_type == "remote"
     assert cfg.hosts[1].path == "starport"
     assert cfg.hosts[2].name == "test"
-    assert cfg.hosts[2].path == "starport"
+    assert cfg.hosts[2].path.endswith("starport")
+    assert os.path.isabs(cfg.hosts[2].path)
     assert cfg.hosts[2].host_type == "local"
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,3 +20,8 @@ def test_backup():
     finally:
         if made_dir:
             shutil.rmtree(test.path)
+
+
+def test_restore():
+    res = cli.main(["restore", "config", "--from=test"])
+    assert res == "No valid backups found. Doing nothing."

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,7 @@ from src.privateer import cli
 from src.privateer.config import PrivateerConfig
 
 
-def test_backup():
+def test_backup_and_restore():
     cfg = PrivateerConfig("config")
     test = cfg.get_host("test")
     made_dir = False
@@ -13,15 +13,19 @@ def test_backup():
         os.mkdir(test.path)
         made_dir = True
     try:
+        # backup
         res = cli.main(["backup", "config", "--to=test"])
         assert res == "Backed up targets 'orderly_volume', 'another_volume' to host 'test'"
         assert os.path.isfile(os.path.join(test.path, "orderly_volume.tar"))
         assert os.path.isfile(os.path.join(test.path, "another_volume.tar"))
+        # restore
+        res = cli.main(["restore", "config", "--from=test"])
+        assert res == "Restored targets 'orderly_volume', 'another_volume' from host 'test'"
     finally:
         if made_dir:
             shutil.rmtree(test.path)
 
 
-def test_restore():
+def test_restore_no_backups():
     res = cli.main(["restore", "config", "--from=test"])
     assert res == "No valid backups found. Doing nothing."


### PR DESCRIPTION
The PR adds the restore logic, skipping any invalid targets but reporting which have failed and which have been restored.

Also adds a check that a valid host name has been passed, which was missing.
