### PR TITLE
mrc-4199 machine keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.*
 dist
 offen
 starport
+another_starport

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ```Usage:
   privateer --version
   privateer backup <path> --to=HOST [--exclude=TARGETS] [--include=TARGETS]
-  privateer restore <path> --from=HOST [--exclude=TARGETS] [--include=TARGETS]
+  privateer restore <path> --from=HOST [--exclude=TARGETS] [--include=TARGETS] [--y]
   privateer schedule <path> --to=HOST [--exclude=TARGETS] [--include=TARGETS]
   privateer status
   privateer cancel [--host=HOST]
@@ -26,12 +26,88 @@ Options:
   --exclude=TARGETS  Comma separated string of target names to exclude (default is to include all)
   --include=TARGETS  Comma separated string of target names to include (default is to include all)
   --host=HOST  Backup host to cancel scheduled backups for (default is to cancel all)
+  --y  Restore without further prompting
 ```
 
 `<path>` is the path to a directory containing a `privateer.json` file. This file should contain at least one target 
 and at least one host. See `./config/privateer.json` for an example. By default all targets in the config file are used, 
-but this can be overridden by explicitly including or excluding targets by name. Backups can be scheduled to multiple 
-hosts simultaneously by running `privateer schedule` multiple times.
+but this can be overridden by explicitly including or excluding targets by name. 
+
+### Manual backups
+Backups can be run manually with `privateer backup`. In this case the backup filename with be of the format:
+
+```<volume_name>-<machine_name>-%Y-%m-%dT%H-%M-%S.tar.gz``` 
+
+where `machine_name` is the name of the soure machine.
+
+### Scheduling
+Backups can be scheduled by specifying cron schedules in `privateer.json` and running `privateer schedule`. 
+In this case backup filenames will be of the format 
+
+```<volume_name>-<schedule_name>-<machine_name>-%Y-%m-%dT%H-%M-%S.tar.gz```
+
+Backups can be scheduled to multiple hosts simultaneously by running `privateer schedule` multiple times.
+
+### Cancelling backups
+Cancel scheduled backups with `privateer cancel`. By default this stops all scheduled backups, but if 
+multiple hosts are being backed up to, backups to a single host can be cancelled using the `--host` option.
+
+### Restoring
+Restoring is always a manual process, run with `privateer restore`. By default it will prompt before restoring each
+target, so that the user can inspect the filename that is being restored (to e.g. check that the backup being restored 
+has the expected machine name). To bypass prompting, pass the `--y` option.
+
+Note that the latest backup will always be restored (restoring from a specific date will be supported in a future release).
+
+### Status
+`privateer status` returns the status of all backups currently scheduled, in json format. E.g.
+
+```bash
+$ privateer status
+2 hosts receiving backups:
+{
+    "host": {
+        "name": "another_test",
+        "host_type": "local",
+        "path": "/home/aehill/Documents/dev/reside/privateer/another_starport"
+    },
+    "targets": [
+        {
+            "name": "another_volume",
+            "type": "volume",
+            "schedules": [
+                {
+                    "name": "custom",
+                    "schedule": "* * * * *",
+                    "retention_days": 12
+                }
+            ]
+        }
+    ]
+}
+{
+    "host": {
+        "name": "test",
+        "host_type": "local",
+        "path": "/home/aehill/Documents/dev/reside/privateer/starport"
+    },
+    "targets": [
+        {
+            "name": "orderly_volume",
+            "type": "volume",
+            "schedules": [
+                {
+                    "name": "daily",
+                    "schedule": "0 2 * * *",
+                    "retention_days": 7
+                }
+            ]
+        }
+    ]
+}
+
+```
+
 
 ## Test and lint
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and at least one host. See `./config/privateer.json` for an example. By default 
 but this can be overridden by explicitly including or excluding targets by name. 
 
 ### Manual backups
-Backups can be run manually with `privateer backup`. In this case the backup filename with be of the format:
+Backups can be run manually with `privateer backup`. In this case the backup filename will be of the format:
 
 ```<volume_name>-<machine_name>-%Y-%m-%dT%H-%M-%S.tar.gz``` 
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Backups can be run manually with `privateer backup`. In this case the backup fil
 
 ```<volume_name>-<machine_name>-%Y-%m-%dT%H-%M-%S.tar.gz``` 
 
-where `machine_name` is the name of the soure machine.
+where `machine_name` is the name of the source machine.
 
 ### Scheduling
 Backups can be scheduled by specifying cron schedules in `privateer.json` and running `privateer schedule`. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
+    "click",
     "docker",
     "docopt",
     "fabric"

--- a/src/privateer/__about__.py
+++ b/src/privateer/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Alex <alex.hill@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.3"
+__version__ = "0.0.4"

--- a/src/privateer/backup.py
+++ b/src/privateer/backup.py
@@ -99,6 +99,8 @@ def schedule_backups(host: PrivateerHost, targets: List[PrivateerTarget]):
             return container.logs().decode("UTF-8")
 
 
+# We do this so that we can retrieve the config for currently running backups at any time (since the user could
+# change the config file on disk, we need to save the config used at the point of starting the container)
 def record_config_in_container(host, targets, container):
     string_into_container(json.dumps({"host": host, "targets": targets}), container, DOCKER_OFFEN_CONFIG_PATH)
 

--- a/src/privateer/cli.py
+++ b/src/privateer/cli.py
@@ -1,7 +1,7 @@
 """Usage:
   privateer --version
   privateer backup <path> --to=HOST [--exclude=TARGETS] [--include=TARGETS]
-  privateer restore <path> --from=HOST [--exclude=TARGETS] [--include=TARGETS]
+  privateer restore <path> --from=HOST [--exclude=TARGETS] [--include=TARGETS] [--y]
   privateer schedule <path> --to=HOST [--exclude=TARGETS] [--include=TARGETS]
   privateer status
   privateer cancel [--host=HOST]
@@ -9,6 +9,8 @@
 Options:
   --exclude=TARGETS  Comma separated string of target names to exclude (default is to include all)
   --include=TARGETS  Comma separated string of target names to include (default is to include all)
+  --host=HOST  Backup host to cancel scheduled backups for (default is to cancel all)
+  --y  Restore without further prompting
 """
 import json
 
@@ -55,7 +57,8 @@ def do_restore(opts):
     if len(targets) == 0:
         return "No targets selected. Doing nothing."
     host = cfg.get_host(opts["--from"])
-    success = restore(host, targets)
+    prompt = not opts["--y"]
+    success = restore(host, targets, prompt)
     if len(success) > 0:
         names = ", ".join([f"'{s}'" for s in success])
         target_str = "targets" if len(success) > 1 else "target"

--- a/src/privateer/cli.py
+++ b/src/privateer/cli.py
@@ -57,8 +57,8 @@ def do_restore(opts):
     if len(targets) == 0:
         return "No targets selected. Doing nothing."
     host = cfg.get_host(opts["--from"])
-    prompt = not opts["--y"]
-    success = restore(host, targets, prompt)
+    require_prompt = not opts["--y"]
+    success = restore(host, targets, require_prompt)
     if len(success) > 0:
         names = ", ".join([f"'{s}'" for s in success])
         target_str = "targets" if len(success) > 1 else "target"

--- a/src/privateer/config.py
+++ b/src/privateer/config.py
@@ -2,6 +2,8 @@ import json
 import os.path
 
 
+# We want these classes to be serializable by the `json` package, so use this base class
+# which inherits from dict and will get correctly serialized by `json.dumps`
 class Serializable(dict):
     def __init__(self):
         dict.__init__(self)

--- a/src/privateer/config.py
+++ b/src/privateer/config.py
@@ -19,7 +19,7 @@ class PrivateerHost(Serializable):
     def __init__(self, dat):
         Serializable.__init__(self)
         host_type = dat["type"]
-        if host_type != "remote" and host_type != "local":
+        if host_type not in ("remote", "local"):
             msg = "Host type must be 'remote' or 'local'."
             raise Exception(msg)
         self.name = dat["name"]

--- a/src/privateer/restore.py
+++ b/src/privateer/restore.py
@@ -18,7 +18,9 @@ def restore_local_backup(host: PrivateerHost, target: PrivateerTarget, require_p
         print(msg)
         return False
     else:
-        if not require_prompt or click.confirm(f"About to restore file {path}. Continue?", default=True):
+        if not require_prompt or click.confirm(
+            f"About to restore file {os.path.basename(path)} from {host.name}. Continue?", default=True
+        ):
             untar_volume(target, path)
             print(f"Restored {path} to {target.name}")
             return True
@@ -31,7 +33,9 @@ def restore_remote_backup(
     res = c.run(f"ls -t {host.path}/{target.name}-*.tar.gz | head -1", in_stream=False, pty=True)
     if res.ok:
         file = res.stdout.strip()
-        if not require_prompt or click.confirm(f"About to restore file {file}. Continue?", default=True):
+        if not require_prompt or click.confirm(
+            f"About to restore file {os.path.basename(file)} from {host.name}. Continue?", default=True
+        ):
             c.get(file, f"{local_backup_path}/")
             untar_volume(target, f"{local_backup_path}/{os.path.basename(file)}")
             print(f"Restored {file} to {target.name}")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -2,11 +2,12 @@ import datetime
 import os
 import tarfile
 import tempfile
+from unittest import mock
 
 import docker
 import pytest
 
-from src.privateer.backup import backup
+from src.privateer.backup import backup, generate_backup_config
 from src.privateer.config import PrivateerConfig, PrivateerTarget
 from src.privateer.docker_helpers import DockerClient
 from src.privateer.restore import get_most_recent_backup, restore, untar_volume
@@ -87,8 +88,10 @@ def test_restore_local():
         v = cl.volumes.get("privateer_test")
         v.remove()
         # restore
-        res = restore(host, [target])
-        assert res == ["privateer_test"]
+        with mock.patch("click.confirm") as prompt:
+            prompt.return_value = True
+            res = restore(host, [target], prompt=False)
+            assert res == ["privateer_test"]
         # check test.txt has been restored to volume
         container = cl.containers.run(
             "ubuntu", mounts=[test_vol], detach=True, command=["test", "-f", "/data/test.txt"]
@@ -96,6 +99,27 @@ def test_restore_local():
         result = container.wait()
         container.remove()
         assert result["StatusCode"] == 0
+        v = cl.volumes.get("privateer_test")
+        v.remove()
+
+
+def test_local_restore_prompt():
+    cfg = PrivateerConfig("config")
+    host = cfg.get_host("test")
+    host.path = tempfile.mkdtemp()
+    target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
+    backup(host, [target])
+    with mock.patch("click.confirm") as prompt:
+        prompt.return_value = False
+        res = restore(host, [target], prompt=True)
+        # when prompt is answered in the negative, nothing gets restored
+        assert len(res) == 0
+    with mock.patch("click.confirm") as prompt:
+        prompt.return_value = True
+        res = restore(host, [target], prompt=True)
+        # when prompt is answered in the affirmative, restore happens
+        assert len(res) == 1
+    with DockerClient() as cl:
         v = cl.volumes.get("privateer_test")
         v.remove()
 
@@ -114,8 +138,9 @@ def test_restore_remote():
         v = cl.volumes.get("privateer_test")
         v.remove()
         # restore
-        res = restore(host, [target])
+        res = restore(host, [target], prompt=False)
         assert res == ["privateer_test"]
+
         # check test.txt has been restored to volume
         container = cl.containers.run(
             "ubuntu", mounts=[test_vol], detach=True, command=["test", "-f", "/data/test.txt"]
@@ -123,6 +148,28 @@ def test_restore_remote():
         result = container.wait()
         container.remove()
         assert result["StatusCode"] == 0
+        v = cl.volumes.get("privateer_test")
+        v.remove()
+
+
+def test_remote_restore_prompt():
+    if os.getenv("GITHUB_ACTIONS"):
+        pytest.skip("No access to network")
+    cfg = PrivateerConfig("config")
+    host = cfg.get_host("uat")
+    target = PrivateerTarget({"name": "privateer_test", "type": "volume"})
+    backup(host, [target])
+    with mock.patch("click.confirm") as prompt:
+        prompt.return_value = False
+        res = restore(host, [target], prompt=True)
+        # when prompt is answered in the negative, nothing gets restored
+        assert len(res) == 0
+    with mock.patch("click.confirm") as prompt:
+        prompt.return_value = True
+        res = restore(host, [target], prompt=True)
+        # when prompt is answered in the affirmative, restore happens
+        assert len(res) == 1
+    with DockerClient() as cl:
         v = cl.volumes.get("privateer_test")
         v.remove()
 
@@ -145,6 +192,37 @@ def test_local_host_dir_validation():
     with pytest.raises(Exception) as err:
         backup(test, cfg.targets)
     assert str(err.value) == "Host path 'badpath' does not exist. Either make directory or fix config."
+
+
+def test_backup_config():
+    cfg = PrivateerConfig("config")
+    target = cfg.targets[0]
+    tmp = tempfile.gettempdir()
+    path = os.path.join(tmp, "test_offen_config")
+    if not os.path.exists(path):
+        os.mkdir(path)
+    generate_backup_config(target, path)
+    files = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+    assert len(files) == 3
+
+    machine = os.uname().nodename
+
+    daily = [f for f in files if "daily" in f][0]
+    lines = open(os.path.join(path, daily)).read().split("\n")
+    assert lines[0] == 'BACKUP_SOURCES="/backup/orderly_volume"'
+    assert lines[1] == f'BACKUP_FILENAME="orderly_volume-daily-{machine}-%Y-%m-%dT%H-%M-%S.tar.gz"'
+    assert lines[2] == f'BACKUP_PRUNING_PREFIX="orderly_volume-daily-{machine}-"'
+    assert lines[3] == 'BACKUP_CRON_EXPRESSION="0 2 * * *"'
+    assert lines[4] == 'BACKUP_RETENTION_DAYS="7"'
+
+    monthly = [f for f in files if "monthly" in f][0]
+    lines = open(os.path.join(path, monthly)).read().split("\n")
+    lines = [line for line in lines if line]
+    assert lines[0] == 'BACKUP_SOURCES="/backup/orderly_volume"'
+    assert lines[1] == f'BACKUP_FILENAME="orderly_volume-monthly-{machine}-%Y-%m-%dT%H-%M-%S.tar.gz"'
+    assert lines[2] == f'BACKUP_PRUNING_PREFIX="orderly_volume-monthly-{machine}-"'
+    assert lines[3] == 'BACKUP_CRON_EXPRESSION="0 4 1 * *"'
+    assert len(lines) == 4
 
 
 def tar_volume(target: PrivateerTarget):

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -207,7 +207,7 @@ def test_backup_config():
 
     machine = os.uname().nodename
 
-    daily = [f for f in files if "daily" in f][0]
+    daily = next(f for f in files if "daily" in f)
     lines = open(os.path.join(path, daily)).read().split("\n")
     assert lines[0] == 'BACKUP_SOURCES="/backup/orderly_volume"'
     assert lines[1] == f'BACKUP_FILENAME="orderly_volume-daily-{machine}-%Y-%m-%dT%H-%M-%S.tar.gz"'
@@ -215,7 +215,7 @@ def test_backup_config():
     assert lines[3] == 'BACKUP_CRON_EXPRESSION="0 2 * * *"'
     assert lines[4] == 'BACKUP_RETENTION_DAYS="7"'
 
-    monthly = [f for f in files if "monthly" in f][0]
+    monthly = next(f for f in files if "monthly" in f)
     lines = open(os.path.join(path, monthly)).read().split("\n")
     lines = [line for line in lines if line]
     assert lines[0] == 'BACKUP_SOURCES="/backup/orderly_volume"'

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -90,7 +90,7 @@ def test_restore_local():
         # restore
         with mock.patch("click.confirm") as prompt:
             prompt.return_value = True
-            res = restore(host, [target], prompt=False)
+            res = restore(host, [target], require_prompt=False)
             assert res == ["privateer_test"]
         # check test.txt has been restored to volume
         container = cl.containers.run(
@@ -111,12 +111,12 @@ def test_local_restore_prompt():
     backup(host, [target])
     with mock.patch("click.confirm") as prompt:
         prompt.return_value = False
-        res = restore(host, [target], prompt=True)
+        res = restore(host, [target], require_prompt=True)
         # when prompt is answered in the negative, nothing gets restored
         assert len(res) == 0
     with mock.patch("click.confirm") as prompt:
         prompt.return_value = True
-        res = restore(host, [target], prompt=True)
+        res = restore(host, [target], require_prompt=True)
         # when prompt is answered in the affirmative, restore happens
         assert len(res) == 1
     with DockerClient() as cl:
@@ -138,7 +138,7 @@ def test_restore_remote():
         v = cl.volumes.get("privateer_test")
         v.remove()
         # restore
-        res = restore(host, [target], prompt=False)
+        res = restore(host, [target], require_prompt=False)
         assert res == ["privateer_test"]
 
         # check test.txt has been restored to volume
@@ -161,12 +161,12 @@ def test_remote_restore_prompt():
     backup(host, [target])
     with mock.patch("click.confirm") as prompt:
         prompt.return_value = False
-        res = restore(host, [target], prompt=True)
+        res = restore(host, [target], require_prompt=True)
         # when prompt is answered in the negative, nothing gets restored
         assert len(res) == 0
     with mock.patch("click.confirm") as prompt:
         prompt.return_value = True
-        res = restore(host, [target], prompt=True)
+        res = restore(host, [target], require_prompt=True)
         # when prompt is answered in the affirmative, restore happens
         assert len(res) == 1
     with DockerClient() as cl:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,7 @@ def test_parse_args():
         assert b.called
 
     res = cli.main(["--version"])
-    assert res == "0.0.3"
+    assert res == "0.0.4"
 
 
 def test_get_targets():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,7 +59,7 @@ def test_restore_no_backups():
     assert res == "No valid backups found. Doing nothing."
 
 
-def xtest_schedule_and_cancel():
+def test_schedule_and_cancel():
     cfg = PrivateerConfig("config")
     test = cfg.get_host("test")
     made_dir = False
@@ -111,7 +111,7 @@ def test_cancel_no_backups():
     assert res == "No backups scheduled. Doing nothing."
 
 
-def xtest_multiple_host_schedules():
+def test_multiple_host_schedules():
     cfg = PrivateerConfig("config")
     test = cfg.get_host("test")
     another = cfg.get_host("another_test")


### PR DESCRIPTION
This PR appends the source machine name to the backup filename and adds an (overridable) prompt to the restore, allowing the user to see which backup they are restoring. This is to avoid the (unlikely) situation in which a volume has been backed up from a staging machine by accident and the user restores that copy of the data to a production machine (also unlikely, since prod machines will rarely use the restore path!) Also just so that we can see at a glance where backups have come from. 

Not yet available: the ability to specify a specific backup to restore - it would be nice if you could maybe list all available backups and then specify one by name to restore, but this isn't a high priority since at the moment, if the user wanted to restore from a backup that is not the most recent, they could just manually delete or move the latest backups out of the starport.

Have also updated the readme to explain the cli more fully, including the new commands added.