### PR TITLE
Allow restore into alternative directory

### DIFF
--- a/src/privateer/cli.py
+++ b/src/privateer/cli.py
@@ -156,6 +156,9 @@ def cli_backup(
 @click.option("--dry-run", is_flag=True, help=help_dry_run)
 @click.option("--source", metavar="NAME", help="Source for the data")
 @click.option("--server", metavar="NAME", help="Server to pull from")
+@click.option(
+    "--to-volume", metavar="NAME", help="Alternate volume to restore to"
+)
 @click.argument("volume")
 def cli_restore(
     path: Path | None,
@@ -163,6 +166,7 @@ def cli_restore(
     volume: str,
     server: str | None,
     source: str | None,
+    to_volume: str | None,
     *,
     dry_run: bool,
 ) -> None:
@@ -173,6 +177,9 @@ def cli_restore(
     where two different machines are backing up the same volume to a
     server.
 
+    If you provide a volume name with `--to-volume`, you can restore into a
+    volume that differs from the upstream name.
+
     """
     root = privateer_root(path)
     name = _find_identity(name, root.path)
@@ -180,6 +187,7 @@ def cli_restore(
         cfg=root.config,
         name=name,
         volume=volume,
+        to_volume=to_volume,
         server=server,
         source=source,
         dry_run=dry_run,

--- a/src/privateer/restore.py
+++ b/src/privateer/restore.py
@@ -41,9 +41,9 @@ def restore(
         print()
         print(f"  {' '.join(cmd)}")
         print()
-        print(f"This will data from the volume '{volume}' stored on the")
+        print(f"This will restore data from the volume '{volume}' stored on the")
         print(
-            f"server '{server}' into into our local volume '{to_volume}'; with"
+            f"server '{server}' into our local volume '{to_volume}'; with"
         ),
         print(f"data originally from '{source}'")
         print()

--- a/src/privateer/restore.py
+++ b/src/privateer/restore.py
@@ -41,10 +41,10 @@ def restore(
         print()
         print(f"  {' '.join(cmd)}")
         print()
-        print(f"This will restore data from the volume '{volume}' stored on the")
         print(
-            f"server '{server}' into our local volume '{to_volume}'; with"
-        ),
+            f"This will restore data from the volume '{volume}' stored on the"
+        )
+        print(f"server '{server}' into our local volume '{to_volume}'; with"),
         print(f"data originally from '{source}'")
         print()
         print("Note that this uses hostname/port information for the server")

--- a/src/privateer/restore.py
+++ b/src/privateer/restore.py
@@ -4,18 +4,30 @@ from privateer.config import find_source
 from privateer.util import match_value, mounts_str, run_container_with_command
 
 
-def restore(cfg, name, volume, *, server=None, source=None, dry_run=False):
+def restore(
+    cfg,
+    name,
+    volume,
+    *,
+    to_volume=None,
+    server=None,
+    source=None,
+    dry_run=False,
+):
     machine = check(cfg, name, quiet=True)
     server = match_value(server, cfg.list_servers(), "server")
     volume = match_value(volume, cfg.list_volumes(), "volume")
+    to_volume = to_volume or volume
     source = find_source(cfg, volume, source)
     image = f"mrcide/privateer-client:{cfg.tag}"
-    dest_mount = f"/privateer/volumes/{volume}"
+    dest_mount = f"/privateer/volumes/{to_volume}"
     mounts = [
         docker.types.Mount(
             "/privateer/keys", machine.key_volume, type="volume", read_only=True
         ),
-        docker.types.Mount(dest_mount, volume, type="volume", read_only=False),
+        docker.types.Mount(
+            dest_mount, to_volume, type="volume", read_only=False
+        ),
     ]
     if source:
         src = f"{server}:/privateer/volumes/{source}/{volume}/"
@@ -29,15 +41,18 @@ def restore(cfg, name, volume, *, server=None, source=None, dry_run=False):
         print()
         print(f"  {' '.join(cmd)}")
         print()
-        print(f"This will data from the server '{server}' into into our")
-        print(f"local volume '{volume}'; data originally from '{source}'")
+        print(f"This will data from the volume '{volume}' stored on the")
+        print(
+            f"server '{server}' into into our local volume '{to_volume}'; with"
+        ),
+        print(f"data originally from '{source}'")
         print()
         print("Note that this uses hostname/port information for the server")
         print("contained within (config), along with our identity (id_rsa)")
         print("in the directory /privateer/keys")
     else:
-        print(f"Restoring '{volume}' from '{server}'; data originally")
-        print(f"from '{source}'")
+        print(f"Restoring '{volume}' from '{server}' to '{to_volume}'")
+        print(f"Data originally from '{source}'")
         run_container_with_command(
             "Restore", image, command=command, mounts=mounts
         )

--- a/src/privateer/util.py
+++ b/src/privateer/util.py
@@ -173,7 +173,7 @@ def rand_str(n=8):
 def log_tail(container, n):
     logs = container.logs().decode("utf-8").strip().split("\n")
     if len(logs) > n:
-        return [f"(ommitting {len(logs) - n} lines of logs)"] + logs[-n:]
+        return [f"(ommitting {len(logs) - n} lines of logs)", *logs[-n:]]
     else:
         return logs
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,7 @@ def test_can_call_restore(tmp_path, mocker):
         volume="data",
         server=None,
         source=None,
+        to_volume=None,
         dry_run=False,
     )
 


### PR DESCRIPTION
This will make some of the montagu database restore path a bit easier as we want to pull from a barman restore volume into a montagu db volume